### PR TITLE
gpio_event.py: introduce invalid syntax to test linter

### DIFF
--- a/lib/python/TI/GPIO/gpio_event.py
+++ b/lib/python/TI/GPIO/gpio_event.py
@@ -38,7 +38,7 @@ except:
 ROOT = "/sys/class/gpio"
 
 # Edge possibilities
-NO_EDGE = 0
+NO_EDGE = 
 RISING_EDGE = 1
 FALLING_EDGE = 2
 BOTH_EDGE = 3


### PR DESCRIPTION
Example bad commit.